### PR TITLE
Fix Cloudflare deployment and update documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,18 @@ clean:
 	rm -rf quartz
 
 publish:
-	pwd
-	CLOUDFLARE_API_TOKEN=$(CLOUDFLARE_API_TOKEN)
-	cd quartz && pnpm dlx wrangler pages deploy public \
+	@echo "Publishing to Cloudflare Pages..."
+	@if [ -z "$(CLOUDFLARE_API_TOKEN)" ]; then \
+		echo "Error: CLOUDFLARE_API_TOKEN is not set"; \
+		exit 1; \
+	fi
+	@if [ -z "$(CLOUDFLARE_PROJECT_NAME)" ]; then \
+		echo "Error: CLOUDFLARE_PROJECT_NAME is not set"; \
+		exit 1; \
+	fi
+	cd quartz && CLOUDFLARE_API_TOKEN=$(CLOUDFLARE_API_TOKEN) pnpm dlx wrangler pages deploy public \
 			--branch=main \
-			--project-name $(CLOUDFLARE_PROJECT_NAME)
+			--project-name=$(CLOUDFLARE_PROJECT_NAME)
 
 deploy: build publish
 	@echo "Deploying to Cloudflare Pages..."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
-# GZen
-Spreading positivity and motivation on the internet. Infecting people with the Good Vibes
+# 观禅 GZen - Observing Zen
 
-## Build Deploy Approach
-- uses a custom GitHub actions that sending the build to CloudFlare page.
-- Hence there isn't any 'Build' options in the CloudFlare
-- see `.github` folder for the workflow details
+A digital sanctuary for Buddhist wisdom and mindful living. Spreading positivity, wisdom, and mindfulness on the internet.
+
+## Build & Deploy Approach
+
+This site uses **Quartz 4** static site generator and deploys to **Cloudflare Pages** via GitHub Actions.
+
+### Deployment Process
+- Custom GitHub Actions workflow builds and deploys to Cloudflare Pages
+- Build happens on GitHub (not on Cloudflare directly)
+- See `.github/workflows/deploy.yml` for workflow details
+
+### Required GitHub Secrets
+Configure these in your repository settings (Settings → Secrets and variables → Actions):
+
+- `CLOUDFLARE_API_TOKEN` - Your Cloudflare API token with Pages write permissions
+- `CLOUDFLARE_PROJECT_NAME` - Your Cloudflare Pages project name (e.g., `gzen-app`)
+
+### Local Development
+```bash
+make setup    # Clone Quartz, link content, install dependencies
+make serve    # Build and serve locally with live reload
+make build    # Build static site
+make clean    # Remove Quartz directory
+```
+
+### Manual Deployment
+```bash
+make deploy   # Build and deploy to Cloudflare Pages
+```


### PR DESCRIPTION
## Fixes

### Makefile Deployment Issues
- **Fixed publish target**: Removed useless CLOUDFLARE_API_TOKEN assignment that did nothing
- **Added validation**: Check for required environment variables before deployment
- **Proper token passing**: Pass CLOUDFLARE_API_TOKEN directly to wrangler command
- **Fixed project-name flag**: Use `--project-name=` format (no space) for wrangler
- **Better error handling**: Exit with clear error messages if secrets are missing

### Changes to publish target:
- Added environment variable validation
- Export CLOUDFLARE_API_TOKEN properly to wrangler subprocess
- Improved logging for deployment steps
- Ensures deployment fails fast with clear errors if misconfigured

## Documentation Updates

### README.md
- **Updated branding**: Reflect new 观禅 GZen (Observing Zen) identity
- **Added deployment documentation**: Clear instructions for GitHub Actions deployment
- **Required secrets section**: Document CLOUDFLARE_API_TOKEN and CLOUDFLARE_PROJECT_NAME
- **Local development guide**: Added make commands reference
- **Better structure**: Organized into clear sections

## Why These Changes?

The original Makefile had line 24:
```makefile
CLOUDFLARE_API_TOKEN=$(CLOUDFLARE_API_TOKEN)
```

This line:
- Doesn't export the variable
- Doesn't pass it to wrangler
- Would cause deployment failures due to missing authentication

The fix ensures:
✅ Token is validated before deployment
✅ Token is properly passed to wrangler command
✅ Clear error messages if configuration is wrong
✅ Deployment will succeed with proper secrets configured

## Testing Recommendation

Before deploying, ensure GitHub repository secrets are configured:
- Settings → Secrets and variables → Actions
- Add CLOUDFLARE_API_TOKEN (from Cloudflare dashboard)
- Add CLOUDFLARE_PROJECT_NAME (your project name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)