### PR TITLE
🎨 Palette: Keyboard Accessible Dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - CSS-Only Keyboard Accessible Dropdown
+**Learning:** Dropdowns created purely with CSS hover states are entirely inaccessible to keyboard users because `hover` does not trigger on focus. Users navigating with Tab cannot open the menu or access its links.
+**Action:** Use `.trigger:focus-visible + .dropdown` and `.dropdown:focus-within` to maintain CSS-only implementation while providing full keyboard access, without needing JavaScript.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -496,6 +496,7 @@ header .logo {
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
+.gzen-nav-dropdown-trigger:focus-visible + .gzen-nav-dropdown-menu,
 .gzen-nav-dropdown-menu:focus-within {
   opacity: 1;
   visibility: visible;
@@ -669,6 +670,7 @@ header .logo {
   }
 
   .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
+  .gzen-nav-dropdown-trigger:focus-visible + .gzen-nav-dropdown-menu,
   .gzen-nav-dropdown-menu:focus-within {
     display: flex;
     opacity: 1;

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -20,10 +20,10 @@
       <a href="{{ .path | relLangURL }}">{{ i18n .key | default .key }}</a>
     {{ end }}
     <div class="gzen-nav-dropdown">
-      <button class="gzen-nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">
-        {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
+      <button class="gzen-nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="ecosystem-menu">
+        {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow" aria-hidden="true">▾</span>
       </button>
-      <div class="gzen-nav-dropdown-menu" role="menu">
+      <div id="ecosystem-menu" class="gzen-nav-dropdown-menu" role="menu">
         <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility to the ecosystem dropdown menu using purely CSS techniques, without requiring JavaScript. Added a journal entry to document the pattern.
🎯 **Why:** Keyboard users cannot open dropdown menus triggered purely by `:hover`. This prevents them from accessing the internal ecosystem navigation links.
♿ **Accessibility:** Users navigating with the "Tab" key can now open the dropdown menu natively since the menu visibility includes `:focus-visible` on the button and `:focus-within` on the dropdown itself. Also linked elements with `aria-controls` for screen reader semantic pairing.

---
*PR created automatically by Jules for task [14063233658637650817](https://jules.google.com/task/14063233658637650817) started by @divineforge*