### PR TITLE
🎨 Palette: Add keyboard focus-visible styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-05 - Added focus-visible states
+**Learning:** The custom CSS implementation completely lacked `focus-visible` styles, meaning keyboard navigation users had no visual indicator of their current position on the site. Since the site uses highly custom CSS with many interactive elements (like the navigation dropdown, ecosystem cards, and link lists), a global focus-visible style using the primary brand color (`rgb(var(--color-primary-500))`) is necessary to ensure keyboard accessibility.
+**Action:** Applied a global `focus-visible` outline to interactive elements (`a`, `button`, `input`, `textarea`, `summary`). Next time dealing with a custom CSS site without a utility framework, always check for keyboard focus styles first.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -780,3 +780,13 @@ header .logo {
 }
 
 
+
+/* ── Accessibility ──────────────────────────────────── */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid rgb(var(--color-primary-500));
+  outline-offset: 2px;
+}


### PR DESCRIPTION
🎨 Palette: Add keyboard focus-visible styles

💡 What: Added global `:focus-visible` styles to interactive elements (`a, button, input, textarea, summary`) in `custom.css`.
🎯 Why: Ensures keyboard navigation users have a clear visual indicator of their current position on the site. Without this, keyboard navigation was largely invisible on custom styled elements.
♿ Accessibility: Added clear outline styles using the brand primary color that only show on keyboard focus (not on mouse clicks), improving WCAG compliance for focus indicators.

---
*PR created automatically by Jules for task [10051536988641141703](https://jules.google.com/task/10051536988641141703) started by @divineforge*