### PR TITLE
🎨 Palette: Fix Dropdown Keyboard Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-10 - Fix Dropdown Keyboard Accessibility
+**Learning:** When using `visibility: hidden` for a dropdown menu, the children of that menu cannot receive focus because they are not considered reachable. Attempting to use `.menu:focus-within` on the hidden element will not work for keyboard users because they can't tab into it to trigger the state.
+**Action:** Always apply `:focus-within` to the *visible parent* (e.g. `.nav-dropdown:focus-within .menu`) instead of the hidden menu itself, ensuring that focusing the trigger button makes the hidden content visible and enterable in the tab order.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -33,7 +33,8 @@ html::before {
   animation: gzen-breathing-bg 22s ease-in-out infinite alternate;
 }
 
-body, .prose {
+body,
+.prose {
   font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
   line-height: 1.8;
 }
@@ -62,7 +63,9 @@ body {
 }
 
 /* Long-form article content uses serif for readability */
-.prose h1, .prose h2, .prose h3 {
+.prose h1,
+.prose h2,
+.prose h3 {
   font-family: "Noto Serif SC", "Noto Sans SC", serif;
   font-weight: 500;
 }
@@ -171,7 +174,9 @@ body {
   line-height: 1.2;
   padding: 0.45rem 0.65rem;
   text-decoration: none;
-  transition: background-color 160ms ease, color 160ms ease;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
 .gzen-nav a:hover,
@@ -243,7 +248,10 @@ body {
   line-height: 1;
   padding: 0.82rem 1.1rem;
   text-decoration: none;
-  transition: transform 160ms cubic-bezier(0.175, 0.885, 0.32, 1.275), background-color 160ms ease, box-shadow 160ms ease;
+  transition:
+    transform 160ms cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    background-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .gzen-primary-link:hover {
@@ -276,7 +284,10 @@ body {
   box-shadow: 0 2px 8px rgba(74, 44, 26, 0.02);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  transition: transform 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
 }
 
 .gzen-hero-aside span:hover {
@@ -456,7 +467,9 @@ header .logo {
   align-items: center;
   gap: 0.2rem;
   font-family: inherit;
-  transition: background-color 160ms ease, color 160ms ease;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-trigger,
@@ -492,11 +505,14 @@ header .logo {
   opacity: 0;
   visibility: hidden;
   transform: translateY(8px);
-  transition: opacity 180ms ease, transform 180ms ease, visibility 180ms ease;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    visibility 180ms ease;
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
-.gzen-nav-dropdown-menu:focus-within {
+.gzen-nav-dropdown:focus-within .gzen-nav-dropdown-menu {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
@@ -551,7 +567,11 @@ header .logo {
   color: inherit;
   position: relative;
   overflow: hidden;
-  transition: transform 180ms cubic-bezier(0.165, 0.84, 0.44, 1), box-shadow 180ms ease, background-color 180ms ease, border-color 180ms ease;
+  transition:
+    transform 180ms cubic-bezier(0.165, 0.84, 0.44, 1),
+    box-shadow 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
 }
 
 .gzen-card::before {
@@ -669,7 +689,7 @@ header .logo {
   }
 
   .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
-  .gzen-nav-dropdown-menu:focus-within {
+  .gzen-nav-dropdown:focus-within .gzen-nav-dropdown-menu {
     display: flex;
     opacity: 1;
     visibility: visible;
@@ -760,7 +780,7 @@ header .logo {
     grid-template-columns: 1fr;
     gap: 2.5rem;
   }
-  
+
   .gzen-footer-links {
     justify-content: space-between;
   }
@@ -771,12 +791,10 @@ header .logo {
     flex-direction: column;
     gap: 1.8rem;
   }
-  
+
   .gzen-footer-bottom {
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
   }
 }
-
-

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -21,25 +22,37 @@
     {{ end }}
     <div class="gzen-nav-dropdown">
       <button class="gzen-nav-dropdown-trigger" aria-haspopup="true" aria-expanded="false">
-        {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
+        {{ i18n "nav_ecosystem" | default "生态" }}
+        <span class="gzen-dropdown-arrow" aria-hidden="true">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
       </div>
     </div>
   </nav>
-
 
   {{ if .IsTranslated }}
     <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">


### PR DESCRIPTION
🎨 Palette: Fix Dropdown Keyboard Accessibility

💡 **What:** 
- Updated the CSS selector for the ecosystem dropdown menu from targeting the hidden menu directly (`.gzen-nav-dropdown-menu:focus-within`) to targeting the parent container (`.gzen-nav-dropdown:focus-within .gzen-nav-dropdown-menu`).
- Added `aria-hidden="true"` to the decorative dropdown arrow (`▾`) in the header.
- Added a new journal entry documenting the specific learning about keyboard accessibility and `visibility: hidden` elements.

🎯 **Why:** 
- When an element has `visibility: hidden`, it and its children are completely removed from the tab order. Keyboard users could not tab into the dropdown menu to trigger its `:focus-within` state, making the ecosystem links inaccessible. By applying the `:focus-within` to the parent `.gzen-nav-dropdown`, tabbing to the visible trigger button now correctly reveals the menu, allowing users to tab through its items.
- Screen readers were likely reading out the literal translation of the downward-pointing triangle symbol, which adds unnecessary noise.

♿ **Accessibility:**
- **Keyboard Navigation:** The ecosystem dropdown menu is now fully navigable via keyboard.
- **Screen Reader Polish:** Decorative characters are now properly hidden from assistive technologies.

---
*PR created automatically by Jules for task [770036250948059044](https://jules.google.com/task/770036250948059044) started by @divineforge*