### PR TITLE
🎨 Palette: Add dynamic ARIA expanded logic to CSS-driven ecosystem dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-05 - Dropdown Accessibility Pattern
+**Learning:** Found an ecosystem dropdown that relies purely on CSS hover/focus but has static ARIA attributes that don't update on interaction. This breaks screen reader expectations.
+**Action:** Add a small JS script to toggle aria-expanded on focus/blur/mouseenter/mouseleave to match the visual state driven by CSS, maintaining accessibility without needing heavy JS frameworks.

--- a/layouts/partials/extend-footer.html
+++ b/layouts/partials/extend-footer.html
@@ -3,3 +3,4 @@
   <script src="/js/lunar.js" defer></script>
 {{ end }}
 <script src="/js/language-toggle.js" defer></script>
+<script src="{{ relURL "js/a11y-dropdown.js" }}" defer></script>

--- a/static/js/a11y-dropdown.js
+++ b/static/js/a11y-dropdown.js
@@ -1,0 +1,49 @@
+/**
+ * GrowZen Accessibility Enhancements
+ * Adds dynamic ARIA attributes for the CSS-driven ecosystem dropdown.
+ */
+;(function () {
+  "use strict"
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var dropdowns = document.querySelectorAll(".gzen-nav-dropdown")
+
+    dropdowns.forEach(function (dropdown) {
+      var trigger = dropdown.querySelector(".gzen-nav-dropdown-trigger")
+      if (!trigger) return
+
+      // Update ARIA on hover
+      dropdown.addEventListener("mouseenter", function () {
+        trigger.setAttribute("aria-expanded", "true")
+      })
+
+      dropdown.addEventListener("mouseleave", function () {
+        trigger.setAttribute("aria-expanded", "false")
+      })
+
+      // Update ARIA on focus (keyboard navigation)
+      dropdown.addEventListener("focusin", function () {
+        trigger.setAttribute("aria-expanded", "true")
+      })
+
+      dropdown.addEventListener("focusout", function (e) {
+        // If the new focused element is not inside the dropdown, set to false
+        if (!dropdown.contains(e.relatedTarget)) {
+          trigger.setAttribute("aria-expanded", "false")
+        }
+      })
+
+      // Handle Escape key to close and return focus to trigger
+      dropdown.addEventListener("keydown", function (e) {
+        if (e.key === "Escape") {
+          trigger.setAttribute("aria-expanded", "false")
+          trigger.focus()
+          // We blur the active element so the focus-within CSS stops applying
+          if (document.activeElement && document.activeElement !== trigger) {
+            document.activeElement.blur()
+          }
+        }
+      })
+    })
+  })
+})()


### PR DESCRIPTION
💡 What: Added a lightweight JS script `a11y-dropdown.js` to toggle the `aria-expanded` state of the ecosystem dropdown on `hover`, `focusin`, and `focusout`. Also added support for dismissing the dropdown with the `Escape` key, which returns focus back to the trigger.
🎯 Why: The dropdown relies entirely on CSS `:hover` and `:focus-within` to display. A static `aria-expanded="false"` attribute remained hardcoded on the trigger, creating mismatched semantics for screen readers during interactions.
♿ Accessibility: Ensures that `aria-expanded` strictly reflects the current visual display state driven by CSS while enhancing keyboard navigation.

---
*PR created automatically by Jules for task [6372043175780664861](https://jules.google.com/task/6372043175780664861) started by @divineforge*