### PR TITLE
🎨 Palette: Fix keyboard accessibility for navigation dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - CSS Hover Menus and Keyboard Focus
+**Learning:** Using `visibility: hidden` on a dropdown menu means it cannot receive keyboard focus naturally. Applying `:focus-within` to the hidden menu itself doesn't work because elements inside it cannot be tabbed to.
+**Action:** Always apply `:focus-within` to the visible parent container (like `.gzen-nav-dropdown`) so that when the visible trigger receives focus, the menu becomes visible, allowing users to tab into its contents.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -460,7 +460,7 @@ header .logo {
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-trigger,
-.gzen-nav-dropdown-trigger:focus {
+.gzen-nav-dropdown:focus-within .gzen-nav-dropdown-trigger {
   background: rgba(217, 120, 69, 0.1);
   color: #8f4526;
 }
@@ -496,7 +496,7 @@ header .logo {
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
-.gzen-nav-dropdown-menu:focus-within {
+.gzen-nav-dropdown:focus-within .gzen-nav-dropdown-menu {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
@@ -669,7 +669,7 @@ header .logo {
   }
 
   .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
-  .gzen-nav-dropdown-menu:focus-within {
+  .gzen-nav-dropdown:focus-within .gzen-nav-dropdown-menu {
     display: flex;
     opacity: 1;
     visibility: visible;


### PR DESCRIPTION
💡 What: Fixed keyboard accessibility for the main navigation "Ecosystem" dropdown and added a learning journal entry.
🎯 Why: The dropdown menu was completely inaccessible to keyboard users because it was hidden by default and only revealed on mouse hover or when elements *inside* it had focus. This created a catch-22 for keyboard navigation. By shifting the `:focus-within` trigger to the parent container, tabbing to the menu button now successfully reveals the submenu links.
♿ Accessibility: Ensures full keyboard navigability for the top-level navigation dropdown according to WCAG guidelines.

---
*PR created automatically by Jules for task [3003458819857039594](https://jules.google.com/task/3003458819857039594) started by @divineforge*