### PR TITLE
🎨 Palette: Add focus-visible keyboard navigation styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Keyboard Navigation Enhancements
+**Learning:** Found that custom buttons, interactive anchor tags, and custom widgets in this Hugo setup often lack `focus-visible` styling, making them difficult to use for keyboard navigators. This affects the accessibility of the site, particularly for the language toggles and custom dropdown menus.
+**Action:** Adding global `focus-visible` styles to `assets/css/custom.css` to ensure all interactive elements receive a clear, thematic outline when focused via keyboard.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -33,7 +33,8 @@ html::before {
   animation: gzen-breathing-bg 22s ease-in-out infinite alternate;
 }
 
-body, .prose {
+body,
+.prose {
   font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
   line-height: 1.8;
 }
@@ -62,7 +63,9 @@ body {
 }
 
 /* Long-form article content uses serif for readability */
-.prose h1, .prose h2, .prose h3 {
+.prose h1,
+.prose h2,
+.prose h3 {
   font-family: "Noto Serif SC", "Noto Sans SC", serif;
   font-weight: 500;
 }
@@ -171,7 +174,9 @@ body {
   line-height: 1.2;
   padding: 0.45rem 0.65rem;
   text-decoration: none;
-  transition: background-color 160ms ease, color 160ms ease;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
 .gzen-nav a:hover,
@@ -243,7 +248,10 @@ body {
   line-height: 1;
   padding: 0.82rem 1.1rem;
   text-decoration: none;
-  transition: transform 160ms cubic-bezier(0.175, 0.885, 0.32, 1.275), background-color 160ms ease, box-shadow 160ms ease;
+  transition:
+    transform 160ms cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    background-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .gzen-primary-link:hover {
@@ -276,7 +284,10 @@ body {
   box-shadow: 0 2px 8px rgba(74, 44, 26, 0.02);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  transition: transform 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
 }
 
 .gzen-hero-aside span:hover {
@@ -456,11 +467,13 @@ header .logo {
   align-items: center;
   gap: 0.2rem;
   font-family: inherit;
-  transition: background-color 160ms ease, color 160ms ease;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-trigger,
-.gzen-nav-dropdown-trigger:focus {
+.gzen-nav-dropdown-trigger:focus-visible {
   background: rgba(217, 120, 69, 0.1);
   color: #8f4526;
 }
@@ -492,7 +505,10 @@ header .logo {
   opacity: 0;
   visibility: hidden;
   transform: translateY(8px);
-  transition: opacity 180ms ease, transform 180ms ease, visibility 180ms ease;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease,
+    visibility 180ms ease;
 }
 
 .gzen-nav-dropdown:hover .gzen-nav-dropdown-menu,
@@ -551,7 +567,11 @@ header .logo {
   color: inherit;
   position: relative;
   overflow: hidden;
-  transition: transform 180ms cubic-bezier(0.165, 0.84, 0.44, 1), box-shadow 180ms ease, background-color 180ms ease, border-color 180ms ease;
+  transition:
+    transform 180ms cubic-bezier(0.165, 0.84, 0.44, 1),
+    box-shadow 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
 }
 
 .gzen-card::before {
@@ -760,7 +780,7 @@ header .logo {
     grid-template-columns: 1fr;
     gap: 2.5rem;
   }
-  
+
   .gzen-footer-links {
     justify-content: space-between;
   }
@@ -771,7 +791,7 @@ header .logo {
     flex-direction: column;
     gap: 1.8rem;
   }
-  
+
   .gzen-footer-bottom {
     flex-direction: column;
     align-items: flex-start;
@@ -779,4 +799,21 @@ header .logo {
   }
 }
 
+/* ── Accessibility ──────────────────────────────────── */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--gzen-saffron);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 
+/* Ensure focus outline respects rounded corners if element has them */
+.gzen-card:focus-visible {
+  border-radius: 12px;
+}
+.gzen-nav-dropdown-trigger:focus-visible {
+  border-radius: 999px;
+}


### PR DESCRIPTION
💡 **What:**
Added global `:focus-visible` styles to `assets/css/custom.css` for interactive elements (`a`, `button`, `input`, `select`, `textarea`). Replaced `:focus` with `:focus-visible` on the `.gzen-nav-dropdown-trigger`.

🎯 **Why:** 
Browsers can have inconsistent focus rings or sometimes they are suppressed by CSS resets. The dropdown trigger used `:focus` which triggers on mouse clicks too, causing a sticky style. This change ensures users navigating with a keyboard have a clear, thematic outline (using the brand saffron color) indicating the currently focused element, without compromising the mouse UX.

♿ **Accessibility:**
Significantly improved keyboard navigation support by making the active focus state clearly visible across the entire application. Added journal entry for this learning.

---
*PR created automatically by Jules for task [10408460955097167202](https://jules.google.com/task/10408460955097167202) started by @divineforge*