### PR TITLE
🎨 Palette: Language Switcher A11y and UX Fix

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-24 - Language Switcher Accessibility
+**Learning:** For a multilingual site, adding `hreflang` and `lang` attributes to language switcher links is critical for screen readers to apply the correct pronunciation profile when reading the foreign language names (e.g., reading "English" in English while navigating the Chinese site). Without this, the screen reader uses the primary language's pronunciation rules, creating confusing auditory experiences. Additionally, relying on isolated JavaScript hooks (like `id="lang-toggle"`) without corresponding markup IDs can lead to broken UX features (like remembering language preference in localStorage).
+**Action:** Always verify that language toggle links have appropriate `hreflang` and `lang` attributes, and ensure JavaScript hooks are correctly bound to the markup elements they target.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -24,15 +25,27 @@
         {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
@@ -40,12 +53,17 @@
     </div>
   </nav>
 
-
   {{ if .IsTranslated }}
-    <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">
+    <nav
+      class="gzen-languages"
+      id="lang-toggle"
+      aria-label="{{ i18n "read_in" | default "Languages" }}">
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          data-lang="{{ .Language.Lang }}"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
🎨 Palette: Enhance language switcher accessibility and reconnect UX hooks

💡 What: Added `id="lang-toggle"` to the languages nav container and `data-lang`, `hreflang`, and `lang` attributes to individual language links.
🎯 Why: Reconnects the `static/js/language-toggle.js` script to properly save language preferences in `localStorage` and provides correct semantic context.
♿ Accessibility: Screen readers will now apply the correct language pronunciation profile when reading out the foreign language links.

---
*PR created automatically by Jules for task [4296520856286095669](https://jules.google.com/task/4296520856286095669) started by @divineforge*