### PR TITLE
🎨 Palette: Add proper a11y attributes to language switcher

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-27 - Improve Language Switcher Accessibility
+**Learning:** Language switchers need `lang` and `hreflang` attributes matching the target language code. Without these, screen readers will incorrectly attempt to read the foreign language text using the current page's language pronunciation profile, resulting in incomprehensible gibberish for users.
+**Action:** Always include `hreflang` and `lang` attributes on language switcher links to ensure proper screen reader pronunciation profiles are applied.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -24,15 +25,27 @@
         {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
@@ -40,12 +53,13 @@
     </div>
   </nav>
 
-
   {{ if .IsTranslated }}
     <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
🎨 **Palette: Language Switcher Accessibility Improvement**

💡 **What:** 
Added `hreflang` and `lang` attributes to the language switcher links in the main header (`layouts/partials/header/basic.html`).

🎯 **Why:** 
Without a `lang` attribute on foreign text, screen readers attempt to read it using the current page's language pronunciation profile. This results in the language switcher links sounding like incomprehensible gibberish to users who rely on screen readers. Adding these attributes ensures the correct pronunciation profile is used and provides proper signals for SEO and browser behavior.

♿ **Accessibility:**
Significantly improves the screen reader experience for multilingual users by correctly defining the language of the switcher links.

**Learnings Recorded:** Documented this critical learning in `.Jules/palette.md` for future reference on multilingual sites.

---
*PR created automatically by Jules for task [17050257026448447097](https://jules.google.com/task/17050257026448447097) started by @divineforge*