### PR TITLE
🎨 Palette: Accessibility improvement for language switchers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-29 - Language Switcher Accessibility
+**Learning:** Screen readers require `lang` and `hreflang` attributes on language switcher links to correctly switch pronunciation profiles when reading the link text (e.g. reading "日本語" with a Japanese voice instead of an English one).
+**Action:** Always include `hreflang="{{ .Language.Lang }}" lang="{{ .Language.Lang }}"` on language toggle links in multilingual Hugo sites.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -24,15 +25,27 @@
         {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
@@ -40,12 +53,13 @@
     </div>
   </nav>
 
-
   {{ if .IsTranslated }}
     <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
💡 What: Added `hreflang` and `lang` attributes to language switcher links.
🎯 Why: Without these attributes, screen readers may mispronounce foreign language names using the current language's pronunciation profile (e.g., reading "日本語" with an English voice).
📸 Before/After: Visuals are unaffected, this is purely an accessibility change for screen readers.
♿ Accessibility: Improved screen reader pronunciation profiles for language switcher links.

---
*PR created automatically by Jules for task [14632253757205733161](https://jules.google.com/task/14632253757205733161) started by @divineforge*