### PR TITLE
🎨 Palette: Enhance Language Switcher Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-04 - Language Switcher Accessibility
+**Learning:** Screen readers rely on `lang` attributes to determine the correct pronunciation profile for text. In multilingual sites, simply changing the text or having an `aria-label` isn't enough; each language link in a switcher needs `lang` and `hreflang` to ensure it's read accurately by assistive technology.
+**Action:** When building or updating multilingual components, always include `lang` and `hreflang` attributes indicating the target language code for each switcher item.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -24,15 +25,27 @@
         {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
@@ -40,12 +53,13 @@
     </div>
   </nav>
 
-
   {{ if .IsTranslated }}
     <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
💡 What: Added `hreflang` and `lang` attributes to the language switcher `<a>` tags in `layouts/partials/header/basic.html` using the target language code.
🎯 Why: Screen readers rely on the `lang` attribute to determine the correct pronunciation profile for text. Without these attributes, screen readers may mispronounce the language names when navigating the switcher. This ensures the correct profile is activated before following the link.
♿ Accessibility: Improved multilingual screen reader accessibility and semantic correctness. Includes a journal entry for the critical learning on multilingual screen reader accessibility.

---
*PR created automatically by Jules for task [4937830720331842787](https://jules.google.com/task/4937830720331842787) started by @divineforge*