### PR TITLE
🎨 Palette: Improve Language Switcher Accessibility (Screen Reader Pronunciation Profiles)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Multilingual Language Switcher Screen Reader Pronunciation Profiles
+**Learning:** When displaying language names in their native format (e.g., "日本語", "English", "中文"), screen readers may mispronounce them by applying the primary document language's voice profile (e.g., trying to read "日本語" with a Chinese or English accent).
+**Action:** Always add `hreflang` and `lang` attributes (e.g., `lang="ja"`) to language switcher links to ensure screen readers switch to the correct pronunciation engine for each language option, improving the accessibility for visually impaired multilingual users.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -6,6 +6,7 @@
   (dict "key" "library" "path" "library")
 }}
 
+
 <header class="gzen-header">
   <a class="gzen-brand" href="{{ "" | relLangURL }}" aria-label="{{ .Site.Title }}">
     <span class="gzen-brand-mark" aria-hidden="true">善</span>
@@ -24,15 +25,27 @@
         {{ i18n "nav_ecosystem" | default "生态" }} <span class="gzen-dropdown-arrow">▾</span>
       </button>
       <div class="gzen-nav-dropdown-menu" role="menu">
-        <a href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.ki | default "https://ki.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>ki.gzen.io</strong>
           <span>{{ i18n "ecosystem_ki_title" | default "机与器" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.learn | default "https://learn.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>learn.gzen.io</strong>
           <span>{{ i18n "ecosystem_learn_title" | default "知与学" }}</span>
         </a>
-        <a href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}" target="_blank" rel="noopener" role="menuitem">
+        <a
+          href="{{ .Site.Params.ecosystem.invest | default "https://invest.gzen.io" }}"
+          target="_blank"
+          rel="noopener"
+          role="menuitem">
           <strong>invest.gzen.io</strong>
           <span>{{ i18n "ecosystem_invest_title" | default "资与财" }}</span>
         </a>
@@ -40,12 +53,17 @@
     </div>
   </nav>
 
-
   {{ if .IsTranslated }}
-    <nav class="gzen-languages" aria-label="{{ i18n "read_in" | default "Languages" }}">
+    <nav
+      id="lang-toggle"
+      class="gzen-languages"
+      aria-label="{{ i18n "read_in" | default "Languages" }}">
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
+          data-lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
🎨 **Palette: Language Switcher Accessibility Improvement**

💡 **What:** Added `hreflang`, `lang`, and `data-lang` attributes to the multilingual language switcher links in the header, and wrapped them in an `id="lang-toggle"` nav container. Documented this critical learning in the Palette journal.

🎯 **Why:** 
1. **Screen Reader Support (a11y):** When displaying language names in their native format (e.g., "日本語", "English", "中文"), screen readers may mispronounce them by applying the primary document language's voice profile. Adding the explicit `lang` attribute ensures screen readers switch to the correct pronunciation engine.
2. **Functionality:** Adding the expected `id="lang-toggle"` and `data-lang` attributes ensures the existing `language-toggle.js` script works correctly to highlight the currently selected secondary language preference stored in local storage.

♿ **Accessibility:** Critical fix for visually impaired multilingual users, ensuring correct auditory feedback when navigating language options.

---
*PR created automatically by Jules for task [10422298731889983267](https://jules.google.com/task/10422298731889983267) started by @divineforge*