### PR TITLE
🎨 Palette: Improve accessibility of language switcher links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-22 - Multilingual Accessible Switcher
+**Learning:** For a multilingual site like GrowZen, language switcher links often display the native name of the language (e.g., "日本語" for Japanese or "English" for English). If the `lang` and `hreflang` attributes are missing from these links, screen readers may attempt to read the text using the current document's language profile, leading to unintelligible pronunciation.
+**Action:** Always include `lang` and `hreflang` attributes on language switcher links that map to the target language code, ensuring screen readers apply the correct pronunciation profile.

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -46,6 +46,8 @@
       {{ range sort .AllTranslations "Language.Weight" }}
         <a
           href="{{ .RelPermalink }}"
+          lang="{{ .Language.Lang }}"
+          hreflang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.LanguageName | default .Language.Lang }}
         </a>


### PR DESCRIPTION
💡 What: Added `lang` and `hreflang` attributes to the language switcher links.
🎯 Why: Without these attributes, screen readers may attempt to read the native language names (e.g., "日本語") using the current document's language profile, resulting in unintelligible pronunciation. Adding `lang` and `hreflang` maps the link text to its target language profile.
♿ Accessibility: Improves screen reader compatibility for multilingual users.
📚 Journal: Added critical learning entry to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [811037766643121707](https://jules.google.com/task/811037766643121707) started by @divineforge*