### PR TITLE
🎨 Palette: Improve accessibility of language switchers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Language Switcher Screen Reader Pronunciation
+**Learning:** Multilingual sites (like this Hugo/Blowfish app) need `hreflang` and `lang` explicitly set on language switcher `<a>` tags. Without them, screen readers may use the current page's language pronunciation engine for the translated names (e.g., trying to read "日本語" with an English voice), resulting in incomprehensible audio.
+**Action:** Always ensure `hreflang` and `lang` attributes are added to language toggle links pointing to localized routes.

--- a/apps/gzen/layouts/partials/header/basic.html
+++ b/apps/gzen/layouts/partials/header/basic.html
@@ -13,7 +13,9 @@
     <a href="{{ "resources" | relLangURL }}">{{ i18n "nav_resources" | default "Resources" }}</a>
     <a href="{{ "playground" | relLangURL }}">{{ i18n "nav_playground" | default "Playground" }}</a>
     <a href="{{ "about" | relLangURL }}">{{ i18n "nav_about" | default "About" }}</a>
-    <a href="{{ "donate" | relLangURL }}" class="gzen-nav-cta">{{ i18n "nav_donate" | default "Donate" }}</a>
+    <a href="{{ "donate" | relLangURL }}" class="gzen-nav-cta"
+      >{{ i18n "nav_donate" | default "Donate" }}</a
+    >
   </nav>
 
   {{ if .IsTranslated }}
@@ -22,6 +24,8 @@
         <a
           href="{{ .RelPermalink }}"
           class="gzen-lang-btn"
+          hreflang="{{ .Language.Lang }}"
+          lang="{{ .Language.Lang }}"
           {{ if eq .Language.Lang $.Site.Language.Lang }}aria-current="page"{{ end }}>
           {{ .Language.Params.displayName | default .Language.Lang }}
         </a>

--- a/apps/gzen/themes/blowfish/layouts/partials/header/components/translations.html
+++ b/apps/gzen/themes/blowfish/layouts/partials/header/components/translations.html
@@ -1,6 +1,9 @@
 {{ if .IsTranslated }}
   <div class="translation nested-menu">
-    <button class="cursor-pointer flex items-center">
+    <button
+      class="cursor-pointer flex items-center"
+      aria-haspopup="menu"
+      aria-label="{{ i18n "global.language" | default "Language options" }}">
       <span class="me-1">
         {{ partial "icon.html" "language" }}
       </span>
@@ -11,7 +14,11 @@
     <ul class="menuhide">
       <li class="rounded-xl backdrop-blur shadow-2xl p-2 flex flex-col gap-1">
         {{ range .AllTranslations }}
-          <a href="{{ .RelPermalink }}" class="flex items-center bf-icon-color-hover px-3 py-1">
+          <a
+            href="{{ .RelPermalink }}"
+            class="flex items-center bf-icon-color-hover px-3 py-1"
+            hreflang="{{ .Language.Lang }}"
+            lang="{{ .Language.Lang }}">
             <span class="text-sm font-sm" title="{{ .Title }}">
               {{ .Language.Params.displayName | emojify }}
             </span>


### PR DESCRIPTION
💡 **What**: Added `hreflang` and `lang` attributes to language switcher links, and enhanced the language dropdown button with `aria-haspopup` and `aria-label`.
🎯 **Why**: When a screen reader encounters translated text without explicit language tags, it may try to read it using the current page's language engine (e.g., trying to read "日本語" with an English voice). This fixes that issue and also provides better context for the dropdown menu button.
♿ **Accessibility**: Improves screen reader pronunciation for multilingual links and enhances keyboard/screen reader navigation for the language menu.

---
*PR created automatically by Jules for task [3393411544204878917](https://jules.google.com/task/3393411544204878917) started by @divineforge*