### PR TITLE
🎨 Palette: Expose custom keyboard shortcuts via ARIA and titles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-25 - Custom Keyboard Shortcuts Must Expose aria-keyshortcuts
+**Learning:** For custom keyboard interactions (like toggling themes with 'T' or accessing door links with 'K, I, L, O'), users of assistive technologies and sighted users alike may be unaware of these shortcuts unless explicitly surfaced via `aria-keyshortcuts` and standard `title` tooltips.
+**Action:** When implementing application-specific hotkeys (e.g., inside `scripts/portal.ts`), verify the associated HTML elements include `aria-keyshortcuts` and a visual indicator like a `title` attribute.

--- a/apps/gzen/src/components/DoorCard.astro
+++ b/apps/gzen/src/components/DoorCard.astro
@@ -16,6 +16,8 @@ const rest = door.name.slice(1);
   class:list={["door", "reveal", delayClass]}
   href={door.href}
   data-door={door.letter}
+  aria-keyshortcuts={door.letter}
+  title={`(Press ${door.letter})`}
   style={`--door-tone: ${door.tone}`}
 >
   <div class="door-inner">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    aria-keyshortcuts="t"
+    title="Cool monastery · warm ignition (Press T)"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 **What:** Added explicit visibility for the custom keyboard shortcuts (T for Theme Toggle, and K, I, L, O for the door links).
🎯 **Why:** To make the application's hidden keyboard shortcuts more discoverable. Without this, users (both sighted and assistive tech users) have no way of knowing these helpful interactions exist. 
♿ **Accessibility:** Added `aria-keyshortcuts` explicitly describing the keybind, and updated standard `title` tooltips for general visual exposure.

---
*PR created automatically by Jules for task [13477965115374636817](https://jules.google.com/task/13477965115374636817) started by @divineforge*