### PR TITLE
🎨 Palette: Add keyboard shortcut hints to interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Add Accessible Keyboard Shortcuts Hints]
+**Learning:** For interactive elements with custom keyboard shortcuts (such as the Theme Toggle or Path Cards), providing an `aria-keyshortcuts` attribute exposes the shortcut to assistive technologies while adding a `title` provides a visual hint for sighted users.
+**Action:** Always include `aria-keyshortcuts` and descriptive `title` attributes on elements bound to custom keyboard shortcuts.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -17,6 +17,8 @@ const poleLabel =
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  aria-keyshortcuts={path.letter}
+  title={`Press ${path.letter} to jump`}
 >
   <div class="path-letter" aria-hidden="true">{path.letter}</div>
 

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition (Press T)"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` to the `ThemeToggle` and `PathCard` components, and updated their titles to visually indicate the shortcut.
🎯 Why: To make existing keyboard shortcuts discoverable for sighted users via native tooltips and announce them to screen reader users via ARIA.
📸 Before/After: Visual titles added (e.g. `(Press T)`).
♿ Accessibility: Better communication of custom keyboard bindings to assistive tech.

---
*PR created automatically by Jules for task [1606133412227780671](https://jules.google.com/task/1606133412227780671) started by @divineforge*