### PR TITLE
🎨 Palette: Add keyboard shortcut hints and ARIA attributes

### DIFF
--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  aria-keyshortcuts={path.letter}
+  title={`Explore ${path.name} (Shortcut: ${path.letter})`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition (T)"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` attributes and descriptive `title` tooltips to interactive elements that utilize custom JavaScript keyboard shortcuts (`T` for ThemeToggle and `K/I/L/O` for PathCards).
🎯 **Why:** To expose custom keyboard shortcuts to assistive technologies (screen readers) and improve discoverability for sighted users, fixing a subtle accessibility/UX gap.
♿ **Accessibility:** Ensures keyboard users and screen reader users are aware of available shortcuts without relying solely on external documentation.
📸 **Before/After:** Verified focus and hover states via Playwright testing and manual review.

---
*PR created automatically by Jules for task [10567483317262575129](https://jules.google.com/task/10567483317262575129) started by @divineforge*