### PR TITLE
🎨 Palette: Add ARIA keyshortcuts to global interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-04 - Keyboard Shortcut Accessibility Pattern
+**Learning:** Custom interactive elements with keyboard shortcuts (like Theme Toggle's 'T' and Path Cards' 'K', 'I', 'L', 'O') need explicit `aria-keyshortcuts` attributes so screen readers can announce them. Sighted users also benefit from a visual hint, often provided in the `title` attribute.
+**Action:** When implementing or modifying interactive elements that have global keyboard shortcut listeners (e.g., via `window.addEventListener('keydown')`), always ensure `aria-keyshortcuts` and a visual `title` hint are present on the corresponding focusable element.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  aria-keyshortcuts={path.letter}
+  title={`Navigate to ${path.name} [${path.letter}]`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition [T]"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` attributes to interactive elements in the UI that have global keyboard shortcut listeners (the Theme Toggle and Path Cards).
🎯 Why: Screen readers cannot automatically discover global keyboard listeners attached to the window. Providing explicit `aria-keyshortcuts` attributes exposes these shortcuts to assistive technologies. Added a visual hint in the `title` attribute for sighted users as well.
📸 Before/After: Visual changes are limited to the native tooltip text, appending the shortcut letter like `[T]` or `[K]`.
♿ Accessibility: Improved keyboard discoverability for all users.
Included a journal entry documenting the learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [15429123362597396481](https://jules.google.com/task/15429123362597396481) started by @divineforge*