### PR TITLE
🎨 Palette: Add keyboard shortcut accessibility hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-05 - Keyboard Shortcut Accessibility Pattern
+**Learning:** Interactive elements in this application (like the Theme Toggle and Path Cards) implement custom keyboard shortcuts (e.g., 'T' for theme, 'K'/'I'/'L'/'O' for paths) without exposing these shortcuts to screen readers or sighted users on hover. This creates a hidden interaction layer that many users will miss.
+**Action:** Always include the `aria-keyshortcuts` attribute on elements with custom JavaScript keyboard bindings, and surface the shortcut visually (e.g., in a `title` attribute or tooltip) so all users can discover them.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -24,6 +24,8 @@ const flowTag: Record<string, string> = {
   class:list={["path", "reveal", delayClass]}
   href={path.href}
   data-path={path.letter}
+  aria-keyshortcuts={path.letter}
+  title={`Go to ${path.name} (${path.letter})`}
   style={`--path-tone: ${path.tone}`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,8 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
-  >
+    aria-keyshortcuts="T"
+    title="Cool monastery · warm ignition (T)">
     <span class="track" aria-hidden="true">
       <span class="knob"></span>
     </span>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` attributes and updated `title` tooltips for components utilizing custom JS keyboard bindings (ThemeToggle for 'T' and PathCard for 'K', 'I', 'L', 'O').
🎯 **Why:** To expose hidden keyboard interactivity to assistive technologies and provide visual discoverability of these shortcuts for all users on hover.
📸 **Before/After:** No major visual layout changes; `title` native tooltip is updated.
♿ **Accessibility:** Screen readers will now announce the available keyboard shortcuts for these interactive elements.

---
*PR created automatically by Jules for task [5459097157970589909](https://jules.google.com/task/5459097157970589909) started by @divineforge*