### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcut accessibility hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Keyboard Shortcuts Accessibility
+**Learning:** Interactive elements with custom keyboard shortcuts (such as Theme Toggle or Door Cards) lack accessibility hints for both screen readers and sighted users if they don't explicitly declare them.
+**Action:** Always include `aria-keyshortcuts` for screen readers and a `title` attribute to provide a visual hint for sighted users when implementing custom keyboard interactions in the app's components.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -24,6 +24,8 @@ const flowTag: Record<string, string> = {
   class:list={["path", "reveal", delayClass]}
   href={path.href}
   data-path={path.letter}
+  aria-keyshortcuts={path.letter}
+  title={`Navigate to ${path.name} (Press ${path.letter})`}
   style={`--path-tone: ${path.tone}`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    aria-keyshortcuts="T"
+    title="Cool monastery · warm ignition (Press T)"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 **What:** Added `aria-keyshortcuts` to screen-reader accessible elements and integrated `(Press T)` or `(Press K)` keyboard shortcut hints into `title` attributes on interactive elements like the ThemeToggle and PathCards in the Astro portal. Also added a journal entry logging this accessibility learning pattern.
🎯 **Why:** Custom keyboard shortcuts designed to improve application flow are often undiscoverable. This enhances usability by making these shortcuts visually available on hover/focus and explicitly broadcast to screen readers via standard ARIA attributes.
♿ **Accessibility:** Improvements to screen reader custom shortcut announcements and visible hints for all keyboard users.

---
*PR created automatically by Jules for task [6051137740900893606](https://jules.google.com/task/6051137740900893606) started by @divineforge*