### PR TITLE
🎨 Palette: Add accessibility hints for global keyboard shortcuts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-08-08 - Keyboard Hints on Global Shortcuts
+**Learning:** Found a recurring pattern where interactive elements that trigger global shortcuts (like 'T' for theme toggle, or 'K/I/L/O' for path cards) lack structural communication of these bindings.
+**Action:** When adding global keyboard shortcuts via event listeners in components, explicitly surface them via `aria-keyshortcuts` on the interactive element and incorporate a text hint in the visual `title` attribute for accessibility.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  aria-keyshortcuts={path.letter}
+  title={`${path.name} (${path.letter})`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,8 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
-  >
+    title="Cool monastery · warm ignition (T)"
+    aria-keyshortcuts="T">
     <span class="track" aria-hidden="true">
       <span class="knob"></span>
     </span>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` attributes and visual `(Key)` text hints to `title` properties on the interactive Theme Toggle and Path Card elements.
🎯 Why: The portal implemented custom global keybindings (e.g., 'T' for theme toggle, 'K/I/L/O' for path cards) via JavaScript listeners on the `window`, but these shortcuts were completely hidden from both screen readers and visual hover states.
📸 Before/After: Sighted users now see a tooltip hint when hovering, and screen readers structural announce the shortcuts.
♿ Accessibility: Dramatically improves keyboard accessibility by adhering to ARIA standards and exposing hidden UI paths.

---
*PR created automatically by Jules for task [7160972823221702719](https://jules.google.com/task/7160972823221702719) started by @divineforge*