### PR TITLE
🎨 Palette: Improve keyboard shortcut discoverability in portal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Keyboard Shortcut Discoverability
+**Learning:** While the portal has global keydown event listeners for quick theme toggling ('T') and jumping to specific sections/paths ('K', 'I', 'L', 'O'), these shortcuts are practically invisible to users—especially those relying on screen readers or those who don't read the documentation. Simply attaching a `keydown` listener in javascript does not provide any discoverability.
+**Action:** Always ensure that custom keyboard shortcuts implemented via JavaScript are paired with appropriate ARIA attributes (specifically `aria-keyshortcuts`) on the corresponding interactive elements. Furthermore, visual hints should be added, typically within the element's `title` attribute or a visible tooltip, so that sighted users are also aware of the available shortcuts (e.g., `title="Cool monastery · warm ignition (Press T)"`).

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -24,6 +24,8 @@ const flowTag: Record<string, string> = {
   class:list={["path", "reveal", delayClass]}
   href={path.href}
   data-path={path.letter}
+  title={`${path.name} (Press ${path.letter})`}
+  aria-keyshortcuts={path.letter}
   style={`--path-tone: ${path.tone}`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition (Press T)"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` attributes and updated `title` tooltips for components with custom JavaScript keydown bindings (Theme toggle and Path cards).
🎯 Why: Custom javascript `keydown` listeners do not inherently expose shortcuts to users. This change makes the 'T', 'K', 'I', 'L', 'O' shortcuts discoverable to screen reader users (via `aria-keyshortcuts`) and sighted users (via updated native tooltips on hover).
📸 Before/After: Visual hints added to native browser tooltips on hover.
♿ Accessibility: Ensures custom keyboard shortcuts comply with discoverability best practices.

---
*PR created automatically by Jules for task [12272142960508128777](https://jules.google.com/task/12272142960508128777) started by @divineforge*