### PR TITLE
🎨 Palette: Add keyboard shortcut hints for accessibility and discovery

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-08-12 - [Accessibility] Discoverable Custom Global Keyboard Shortcuts
+**Learning:** Custom global keyboard shortcuts mapped in javascript (like T for theme, and K/I/L/O for portal paths) are completely invisible to users unless properly documented in the DOM. Sighted users won't know they exist, and screen readers won't announce them.
+**Action:** When adding global JS event listeners for shortcut keys on interactive elements, always pair them with the `aria-keyshortcuts` attribute for assistive technology, and expose the shortcut text visibly (e.g., via `title` attribute) so sighted users can also learn and utilize the shortcut.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  title={`${path.name} (Press ${path.letter})`}
+  aria-keyshortcuts={path.letter}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition (Press T)"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 **What**: The UX enhancement added exposes the custom global keyboard shortcuts (like `T` for theme toggle, `K`/`I`/`L`/`O` for path selection) by using standard `aria-keyshortcuts` and appending a hint to the `title` attribute.
🎯 **Why**: Previously, these keyboard shortcuts were entirely hidden. Sighted users wouldn't know they existed, and screen readers couldn't announce them, making the interactions undiscoverable.
📸 **Before/After**: Screenshots successfully captured and verified.
♿ **Accessibility**: Significant improvement for users relying on screen readers or keyboard navigation, as shortcuts are now explicitly tied to the DOM elements they trigger.

---
*PR created automatically by Jules for task [1066333908136817496](https://jules.google.com/task/1066333908136817496) started by @divineforge*