### PR TITLE
🎨 Palette: Add accessibility keyboard shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Keyboard Shortcut Discoverability
+**Learning:** Hidden keyboard shortcuts (like "T" for theme toggle and K/I/L/O for paths) are great for power users but often go undiscovered, and fail WCAG guidelines if they lack accessible indications. Exposing them via standard `aria-keyshortcuts` allows screen readers to announce them, and adding them to the `title` attribute provides a non-intrusive tooltip for sighted mouse users to discover them naturally.
+**Action:** Always add `aria-keyshortcuts` and append `(Shortcut: [Key])` to the `title` attribute on elements that have hidden global or local keyboard shortcut event listeners.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  title={`${path.name} (Shortcut: ${path.letter})`}
+  aria-keyshortcuts={path.letter}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,7 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
+    title="Cool monastery · warm ignition (Shortcut: T)"
+    aria-keyshortcuts="T"
   >
     <span class="track" aria-hidden="true">
       <span class="knob"></span>


### PR DESCRIPTION
💡 **What:** Added accessibility indications for hidden keyboard shortcuts to the gZen portal.
🎯 **Why:** Hidden keyboard shortcuts (like "T" for theme toggle and K/I/L/O for paths) were completely undiscoverable to both sighted users and screen reader users, failing WCAG discoverability guidelines.
♿ **Accessibility:**
- Added `aria-keyshortcuts` attributes to interactive elements so screen readers can announce available shortcuts.
- Appended `(Shortcut: [Key])` to `title` attributes to act as native tooltips, allowing mouse users to discover shortcuts naturally.

---
*PR created automatically by Jules for task [14191450492986822488](https://jules.google.com/task/14191450492986822488) started by @divineforge*