### PR TITLE
🎨 Palette: Add keyboard shortcut discoverability and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-14 - Custom Keyboard Shortcut Accessibility
+**Learning:** Interactive elements with custom keyboard shortcuts (like Theme Toggle or Path Cards) often lack discoverability for sighted users and fail to announce shortcuts to screen readers.
+**Action:** Always add the `aria-keyshortcuts` attribute for screen readers and append `(Shortcut: [Key])` to the `title` attribute for visual tooltips to maintain non-intrusive accessibility.

--- a/apps/gzen/src/components/PathCard.astro
+++ b/apps/gzen/src/components/PathCard.astro
@@ -25,6 +25,8 @@ const flowTag: Record<string, string> = {
   href={path.href}
   data-path={path.letter}
   style={`--path-tone: ${path.tone}`}
+  aria-keyshortcuts={path.letter}
+  title={`${path.name} (Shortcut: ${path.letter})`}
 >
   <!-- Symbolic icon for each K.I.L.O. portal -->
   <div class="path-icon" aria-hidden="true">

--- a/apps/gzen/src/components/ThemeToggle.astro
+++ b/apps/gzen/src/components/ThemeToggle.astro
@@ -8,8 +8,8 @@
     class="theme-toggle"
     id="theme-toggle"
     aria-label="Switch temperature: cool monastery or warm ignition"
-    title="Cool monastery · warm ignition"
-  >
+    title="Cool monastery · warm ignition (Shortcut: T)"
+    aria-keyshortcuts="T">
     <span class="track" aria-hidden="true">
       <span class="knob"></span>
     </span>


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` and visual title tooltips to interactive elements with custom keyboard shortcuts (Theme Toggle and Path Cards).
🎯 Why: While custom shortcuts ("T" for theme, "K,I,L,O" for paths) were functional, they were completely hidden from sighted users (except for a bottom hint hidden on mobile) and not properly announced to screen readers.
♿ Accessibility: Improves WCAG compliance by exposing keyboard shortcuts programmatically to assistive tech via `aria-keyshortcuts` and visually to hover users via the `title` attribute.

---
*PR created automatically by Jules for task [4410699625019061351](https://jules.google.com/task/4410699625019061351) started by @divineforge*