### PR TITLE
🎨 Palette: Add keyboard shortcut discoverability to Element Cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Discoverability for Keyboard Interactive Elements
+ **Learning:** Interactive elements with custom keyboard shortcuts (such as the Path Cards in the Astro portal) often lack discoverability for both screen reader users and sighted users. While the shortcut logic exists in JavaScript, the UI components themselves were not exposing this.
+ **Action:** For any element utilizing a custom keyboard shortcut, include `aria-keyshortcuts` attribute for screen reader pronunciation and add `(Shortcut: [Key])` to the `title` attribute to provide a non-intrusive visual tooltip on hover.

--- a/apps/gzen/src/components/ElementCard.astro
+++ b/apps/gzen/src/components/ElementCard.astro
@@ -16,6 +16,8 @@ const delayClass = `reveal-d${Math.min(index + 1, 5)}`;
   href={element.href}
   data-element={element.letter}
   style={`--element-tone: ${element.tone}; --element-secondary: ${element.toneSecondary}; --element-gradient: ${element.gradient}`}
+  aria-keyshortcuts={element.shortcut}
+  title={`Navigate to ${element.name} (Shortcut: ${element.shortcut})`}
 >
   <!-- Specular Ambient Floor Glow under card glass -->
   <div class="element-ambient-glow" aria-hidden="true"></div>


### PR DESCRIPTION
🎨 Palette: Keyboard Shortcut Discoverability for Path Cards

💡 **What:** Added `aria-keyshortcuts` and `title` attributes to the main `<a>` element in `ElementCard.astro`.
🎯 **Why:** The Element Cards (Z, E, N paths) have custom keyboard shortcuts to trigger them, but this functionality was previously completely invisible to both screen readers (no ARIA hint) and sighted users (no visual tooltip on hover).
📸 **Before/After:** Verified via Playwright tests and videos showing the hover states.
♿ **Accessibility:** Screen readers will now announce the shortcut during navigation, and sighted users can discover the shortcut natively via browser hover.

Also documented this learning in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [18242186645342207359](https://jules.google.com/task/18242186645342207359) started by @divineforge*