### PR TITLE
🎨 Palette: Add keyboard shortcut hints to element cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-08-18 - Interactive element shortcuts
+
+**Learning:** Sighted users were unaware of the hidden 'Z', 'E', 'N' keyboard shortcuts for element cards, and screen readers lacked the contextual relationship for them.
+**Action:** Always append `(Shortcut: [Key])` to `title` tags on interactables with custom keybinds and ensure the `aria-keyshortcuts` attribute is provided.

--- a/apps/gzen/src/components/ElementCard.astro
+++ b/apps/gzen/src/components/ElementCard.astro
@@ -15,6 +15,8 @@ const delayClass = `reveal-d${Math.min(index + 1, 5)}`;
   id={`element-${element.letter}`}
   href={element.href}
   data-element={element.letter}
+  aria-keyshortcuts={element.shortcut}
+  title={`(Shortcut: ${element.shortcut})`}
   style={`--element-tone: ${element.tone}; --element-secondary: ${element.toneSecondary}; --element-gradient: ${element.gradient}`}
 >
   <!-- Specular Ambient Floor Glow under card glass -->


### PR DESCRIPTION
💡 What: Added `aria-keyshortcuts` and `title` attributes (with a shortcut hint) to the Element Card component in the portal. Also recorded the learning in Palette's journal.
🎯 Why: Sighted users were unaware of the hidden 'Z', 'E', 'N' keyboard shortcuts for element cards, and screen readers lacked the contextual relationship for them.
♿ Accessibility: Ensures that screen reader users can discover the keyboard shortcuts via `aria-keyshortcuts` and provides a native discoverable tooltip for sighted users.

---
*PR created automatically by Jules for task [3132231870592956765](https://jules.google.com/task/3132231870592956765) started by @divineforge*